### PR TITLE
Fix tool log alignment

### DIFF
--- a/src/hooks/useStreamingChat.tsx
+++ b/src/hooks/useStreamingChat.tsx
@@ -17,7 +17,7 @@ export interface StreamingState {
 
 export const useStreamingChat = (
   activeThreadId: string | null,
-  onMessageComplete: (content: string) => void
+  onMessageComplete: (content: string, steps: StreamStep[]) => void
 ) => {
   const [streamingState, setStreamingState] = useState<StreamingState>({
     isStreaming: false,
@@ -111,7 +111,7 @@ export const useStreamingChat = (
         isStreaming: false
       }));
 
-      onMessageComplete(accumulatedContent);
+      onMessageComplete(accumulatedContent, steps);
 
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
@@ -149,7 +149,7 @@ export const useStreamingChat = (
       ...prev,
       isStreaming: false
     }));
-    onMessageComplete(streamingState.currentContent);
+    onMessageComplete(streamingState.currentContent, streamingState.steps);
   };
 
   return {


### PR DESCRIPTION
## Summary
- ensure tool log steps are linked to the correct message
- pass step list from `useStreamingChat` to the callback
- track the streaming message index in `useMessages`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb94c7b1c83268df9a866d0059b83